### PR TITLE
✨ Modify Guzzle request log to show whether the request was from the cache (HIT) or was actually executed (MISS)

### DIFF
--- a/src/Commands/Traits/HttpTrait.php
+++ b/src/Commands/Traits/HttpTrait.php
@@ -35,7 +35,7 @@ trait HttpTrait
             $logger,
             new MessageFormatter('{method} {code} <href={uri}>{uri}</> [Cache {res_header_' . strtolower(CacheMiddleware::HEADER_CACHE_INFO) . '}]'),
             LogLevel::DEBUG,
-        ));
+        ), 'logger');
 
         if (!$noHttpCache) {
             $dir = '/tmp/dogit/http_cache/';

--- a/src/Commands/Traits/HttpTrait.php
+++ b/src/Commands/Traits/HttpTrait.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Cookie\SetCookie;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\RequestOptions;
 use Http\Adapter\Guzzle7\Client;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Kevinrob\GuzzleCache\CacheMiddleware;
@@ -32,7 +33,7 @@ trait HttpTrait
     {
         $this->handlerStack()->push(Middleware::log(
             $logger,
-            new MessageFormatter('{method} {code} <href={uri}>{uri}</>'),
+            new MessageFormatter('{method} {code} <href={uri}>{uri}</> [Cache {res_header_' . strtolower(CacheMiddleware::HEADER_CACHE_INFO) . '}]'),
             LogLevel::DEBUG,
         ));
 
@@ -49,8 +50,8 @@ trait HttpTrait
         $httpFactory = Psr17FactoryDiscovery::findRequestFactory();
         $httpAsyncClient = new Client(new GuzzleClient([
             'handler' => $this->handlerStack(),
-            'cookies' => $cookieJar,
-            'headers' => [
+            RequestOptions::COOKIES => $cookieJar,
+            RequestOptions::HEADERS => [
                 'User-Agent' => 'Dogit www.dogit.dev',
             ],
         ]));

--- a/tests/Commands/Traits/HttpTraitTest.php
+++ b/tests/Commands/Traits/HttpTraitTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace dogit\tests\Commands;
+
+use dogit\Commands\Traits\HttpTrait;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Psr7\Response;
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @coversDefaultClass \dogit\Commands\Traits\HttpTrait
+ */
+final class HttpTraitTest extends TestCase
+{
+    public function testLogs(): void
+    {
+        $command = new class() {
+            use HttpTrait {
+                http as originalHttp;
+            }
+
+            /**
+             * @param string[] $cookies
+             *
+             * @return array{0:\Psr\Http\Message\RequestFactoryInterface, 1:\Http\Client\HttpClient&\Http\Client\HttpAsyncClient}
+             */
+            public function http(LoggerInterface $logger, bool $noHttpCache = false, array $cookies = [])
+            {
+                return $this->originalHttp($logger, $noHttpCache, $cookies);
+            }
+        };
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->exactly(1))
+            ->method('log')
+            ->withConsecutive(
+                ['debug', 'GET 200 <href=http://example.com/foo>http://example.com/foo</> [Cache MISS]']
+            );
+        $logger->expects($this->never())
+            ->method('error');
+
+        [$httpFactory, $httpAsyncClient] = $command->http($logger);
+        $this->assertInstanceOf(RequestFactoryInterface::class, $httpFactory);
+        $this->assertInstanceOf(HttpClient::class, $httpAsyncClient);
+        $this->assertInstanceOf(HttpAsyncClient::class, $httpAsyncClient);
+
+        $command->handlerStack()->push(function (callable $handler): callable {
+            return static function ($request, array $options) {
+                return new FulfilledPromise(
+                    new Response(200, [
+                        'Content-Type' => 'text/plain',
+                    ], 'All requests are caught for tests'),
+                );
+            };
+        }, 'request_killer');
+
+        $request = $httpFactory->createRequest('GET', 'http://example.com/foo');
+        $promise = $httpAsyncClient->sendAsyncRequest($request);
+        $response = $promise->wait();
+        $this->assertEquals('All requests are caught for tests', (string) $response->getBody());
+    }
+}

--- a/tests/Commands/Traits/HttpTraitTest.php
+++ b/tests/Commands/Traits/HttpTraitTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace dogit\tests\Commands;
+namespace dogit\tests\Commands\Traits;
 
 use dogit\Commands\Traits\HttpTrait;
 use GuzzleHttp\Promise\FulfilledPromise;


### PR DESCRIPTION
Fixes #15