### PR TITLE
🎨 Added PHPStan strict rules and address reported issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "mikey179/vfsstream": "^1.6.10",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "1.7.14",
+        "phpstan/phpstan-strict-rules": "^1.2",
         "phpstan/phpstan-symfony": "^1",
         "phpunit/phpunit": "^9.5.20"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpspec/prophecy-phpunit": "^2.0",
         "psr/http-client": "^1.0",
         "psr/log": "^2.0",
-        "symfony/browser-kit": "^5.3",
+        "symfony/browser-kit": "^5.3.1",
         "symfony/console": "^5.3",
         "symfony/css-selector": "^5.3",
         "symfony/dom-crawler": "^5.4",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,3 +6,5 @@ parameters:
 		- ./tests
 	symfony:
 		console_application_loader: phpstan/console-application.php
+	ignoreErrors:
+		- '#Dynamic call to static method PHPUnit\\Framework\\.*#'

--- a/src/Commands/IssueTimelineCommand.php
+++ b/src/Commands/IssueTimelineCommand.php
@@ -78,16 +78,16 @@ final class IssueTimelineCommand extends Command
             $comments[$event->getComment()->id()][] = $event;
         }
 
-        foreach ($comments as $events) {
-            $firstComment = reset($events)->getComment();
+        foreach ($comments as $commentEvents) {
+            $firstComment = reset($commentEvents)->getComment();
             $io->title(sprintf('<href=%s>Comment #%s (%d) at %s</>',
                 $firstComment->url(),
                 $firstComment->id(),
                 $firstComment->getSequence(),
                 $firstComment->getCreated()->format('r'),
             ));
-            foreach ($events as $event) {
-                $io->text((string) $event);
+            foreach ($commentEvents as $commentEvent) {
+                $io->text((string) $commentEvent);
             }
         }
 

--- a/src/Commands/Options/IssueMergeRequestOptions.php
+++ b/src/Commands/Options/IssueMergeRequestOptions.php
@@ -31,7 +31,7 @@ final class IssueMergeRequestOptions
         $instance->cookies = $input->getOption(static::OPTION_COOKIE);
         $directory = (string) $input->getArgument(static::ARGUMENT_DIRECTORY);
         $cwd = \getcwd();
-        $instance->directory = ('.' === $directory && $cwd) ? $cwd : $directory;
+        $instance->directory = ('.' === $directory && is_string($cwd)) ? $cwd : $directory;
         $instance->isHttp = $input->getOption(static::OPTION_HTTP);
 
         $nid = $input->getArgument(static::ARGUMENT_ISSUE_ID);

--- a/src/Commands/Options/IssueTimelineCommandOptions.php
+++ b/src/Commands/Options/IssueTimelineCommandOptions.php
@@ -22,7 +22,7 @@ final class IssueTimelineCommandOptions
 
         /** @var string $nid */
         $nid = $input->getArgument(static::ARGUMENT_ISSUE_ID);
-        $instance->nid = preg_match('/^\d{1,10}$/m', $nid) ? (int) $nid : throw new \UnexpectedValueException('Issue ID is not valid');
+        $instance->nid = (1 === preg_match('/^\d{1,10}$/m', $nid)) ? (int) $nid : throw new \UnexpectedValueException('Issue ID is not valid');
         $instance->noComments = (bool) $input->getOption(static::OPTION_NO_COMMENTS);
         $instance->noEvents = (bool) $input->getOption(static::OPTION_NO_EVENTS);
 

--- a/src/Commands/Options/PatchToBranchOptions.php
+++ b/src/Commands/Options/PatchToBranchOptions.php
@@ -65,7 +65,7 @@ final class PatchToBranchOptions
 
         // Check is a proper Composer constraint. e.g 8.8.x is not accepted:
         $constraint = (string) $input->getArgument(static::ARGUMENT_VERSION_CONSTRAINTS);
-        if (!empty($constraint)) {
+        if (strlen($constraint) > 0) {
             try {
                 (new VersionParser())->parseConstraints($constraint);
             } catch (\UnexpectedValueException $e) {

--- a/src/Commands/Options/ProjectMergeRequestOptions.php
+++ b/src/Commands/Options/ProjectMergeRequestOptions.php
@@ -33,7 +33,7 @@ final class ProjectMergeRequestOptions
         $instance->branchName = $input->getOption(static::OPTION_BRANCH);
         $directory = (string) $input->getArgument(static::ARGUMENT_DIRECTORY);
         $cwd = \getcwd();
-        $instance->directory = ('.' === $directory && $cwd) ? $cwd : $directory;
+        $instance->directory = ('.' === $directory && is_string($cwd)) ? $cwd : $directory;
         $instance->project = $input->getArgument(static::ARGUMENT_PROJECT);
         $instance->isHttp = $input->getOption(static::OPTION_HTTP);
         $instance->includeAll = (bool) $input->getOption(static::OPTION_ALL);

--- a/src/Commands/ProjectCloneCommand.php
+++ b/src/Commands/ProjectCloneCommand.php
@@ -51,14 +51,14 @@ class ProjectCloneCommand extends Command
 
         $url = sprintf($options->isHttp ? 'https://git.drupalcode.org/project/%s.git' : 'git@git.drupal.org:project/%s.git', $options->project);
         $params = [];
-        if (!empty($options->branch)) {
+        if (null !== $options->branch && strlen($options->branch) > 0) {
             $params['-b'] = $options->branch;
         }
 
         // When directory isnt provided then use a directory with the same name as the project, if the directory
         // doesn't exist.
         $directory = $options->directory;
-        if (!$directory) {
+        if (null === $directory) {
             $directory = $options->project;
         }
 

--- a/src/DrupalOrg/IssueGraph/DrupalOrgIssueGraph.php
+++ b/src/DrupalOrg/IssueGraph/DrupalOrgIssueGraph.php
@@ -74,7 +74,7 @@ class DrupalOrgIssueGraph
             yield new CommentEvent($commentStub);
 
             // Detect merge requests.
-            if (count($branchMrs) > 0 && $repoUrlGit && $repoUrlHttp) {
+            if (count($branchMrs) > 0 && null !== $repoUrlGit && null !== $repoUrlHttp) {
                 $fieldItems = $commentCrawler->filter('.field-items > *');
                 foreach ($fieldItems as $fieldItem) {
                     if (str_contains($fieldItem->textContent, 'opened merge request !')) {
@@ -172,7 +172,7 @@ class DrupalOrgIssueGraph
         foreach ($crawler->filter('#content .comments > .comment') as $commentElement) {
             assert($commentElement instanceof \DOMElement);
             $id = $commentElement->getAttribute('id');
-            if (empty($id)) {
+            if (0 === strlen($id)) {
                 throw new \LogicException('All comments are expected to have an ID.');
             }
 

--- a/src/DrupalOrg/Objects/DrupalOrgComment.php
+++ b/src/DrupalOrg/Objects/DrupalOrgComment.php
@@ -22,7 +22,9 @@ class DrupalOrgComment extends DrupalOrgObject
 
     public function getCreated(): \DateTimeImmutable
     {
-        !$this->isStub ?: throw new \DomainException('Data missing for stubs.');
+        if ($this->isStub) {
+            throw new \DomainException('Data missing for stubs.');
+        }
         $timestamp = $this->data->created ?? throw new \DomainException('Missing created date');
 
         return new \DateTimeImmutable('@' . $timestamp);
@@ -67,7 +69,9 @@ class DrupalOrgComment extends DrupalOrgObject
 
     public function getIssue(): DrupalOrgIssue
     {
-        !$this->isStub ?: throw new \DomainException('Data missing for stubs.');
+        if ($this->isStub) {
+            throw new \DomainException('Data missing for stubs.');
+        }
 
         return $this->repository->share(DrupalOrgIssue::fromStub($this->data->node));
     }
@@ -88,7 +92,7 @@ class DrupalOrgComment extends DrupalOrgObject
     {
         $commentBody = $this->data->comment_body ?? throw new \DomainException('Data missing for stubs.');
 
-        return !empty($commentBody->value) ? $commentBody->value : '';
+        return isset($commentBody->value) && strlen($commentBody->value) > 0 ? $commentBody->value : '';
     }
 
     public function importResponse(ResponseInterface $response): static

--- a/src/DrupalOrg/Objects/DrupalOrgFile.php
+++ b/src/DrupalOrg/Objects/DrupalOrgFile.php
@@ -17,14 +17,18 @@ class DrupalOrgFile extends DrupalOrgObject
 
     public function getMime(): string
     {
-        !$this->isStub ?: throw new \DomainException('Data missing for stubs.');
+        if ($this->isStub) {
+            throw new \DomainException('Data missing for stubs.');
+        }
 
         return $this->data->mime ?? throw new \DomainException('Missing mime type');
     }
 
     public function getCreated(): \DateTimeImmutable
     {
-        !$this->isStub ?: throw new \DomainException('Data missing for stubs.');
+        if ($this->isStub) {
+            throw new \DomainException('Data missing for stubs.');
+        }
         $timestamp = $this->data->timestamp ?? throw new \DomainException('Missing created date');
 
         return new \DateTimeImmutable('@' . $timestamp);
@@ -32,7 +36,9 @@ class DrupalOrgFile extends DrupalOrgObject
 
     public function getUrl(): string
     {
-        !$this->isStub ?: throw new \DomainException('Data missing for stubs.');
+        if ($this->isStub) {
+            throw new \DomainException('Data missing for stubs.');
+        }
 
         return $this->data->url ?? throw new \DomainException('Missing URL');
     }

--- a/src/DrupalOrg/Objects/DrupalOrgIssue.php
+++ b/src/DrupalOrg/Objects/DrupalOrgIssue.php
@@ -17,7 +17,9 @@ class DrupalOrgIssue extends DrupalOrgObject
 
     public function getCreated(): \DateTimeImmutable
     {
-        !$this->isStub ?: throw new \DomainException('Data missing for stubs.');
+        if ($this->isStub) {
+            throw new \DomainException('Data missing for stubs.');
+        }
         $timestamp = $this->data->created ?? throw new \DomainException('Missing created date');
 
         return new \DateTimeImmutable('@' . $timestamp);
@@ -25,7 +27,9 @@ class DrupalOrgIssue extends DrupalOrgObject
 
     public function getCurrentVersion(): string
     {
-        !$this->isStub ?: throw new \DomainException('Data missing for stubs.');
+        if ($this->isStub) {
+            throw new \DomainException('Data missing for stubs.');
+        }
 
         return $this->data->field_issue_version ?? throw new \DomainException('Missing issue version');
     }

--- a/src/Git/GitOperator.php
+++ b/src/Git/GitOperator.php
@@ -17,17 +17,17 @@ final class GitOperator
 
     public function isClean(): bool
     {
-        return empty($this->gitRepository->execute('status', '--porcelain'));
+        return 0 === count($this->gitRepository->execute('status', '--porcelain'));
     }
 
     public function resetHard(?string $treeIsh = null): bool
     {
         $args = ['reset', '--hard', '--quiet'];
-        if ($treeIsh) {
+        if (null !== $treeIsh) {
             $args[] = $treeIsh;
         }
 
-        return empty($this->gitRepository->execute(...$args));
+        return 0 === count($this->gitRepository->execute(...$args));
     }
 
     public function clean(): void
@@ -114,7 +114,7 @@ final class GitOperator
     public function renameBranch(string $newBranchName, string $oldBranchName = null): void
     {
         $args = ['branch', '-M'];
-        if ($oldBranchName) {
+        if (null !== $oldBranchName) {
             $args[] = $oldBranchName;
         }
         $args[] = $newBranchName;

--- a/src/Git/GitResolver.php
+++ b/src/Git/GitResolver.php
@@ -24,7 +24,7 @@ final class GitResolver
             sprintf('remotes/origin/%s', $this->patch->getGitReference()),
         ]);
 
-        if (!$return) {
+        if (0 === count($return)) {
             throw new \Exception('Failed to get hash.');
         }
 

--- a/src/HttplugBrowser.php
+++ b/src/HttplugBrowser.php
@@ -6,7 +6,9 @@ namespace dogit;
 
 use Http\Client\HttpAsyncClient;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
 use Symfony\Component\BrowserKit\AbstractBrowser;
+use Symfony\Component\BrowserKit\Request;
 use Symfony\Component\BrowserKit\Response;
 
 final class HttplugBrowser extends AbstractBrowser
@@ -21,11 +23,10 @@ final class HttplugBrowser extends AbstractBrowser
         $this->httpClient = $httpClient;
     }
 
-    /**
-     * @param \Psr\Http\Message\RequestInterface|\Symfony\Component\BrowserKit\Request $request
-     */
-    protected function doRequest($request): Response
+    protected function doRequest(object $request): Response
     {
+        assert($request instanceof RequestInterface || $request instanceof Request);
+
         $response = $this->httpClient->sendAsyncRequest(
             $this->httpFactory->createRequest($request->getMethod(), $request->getUri())
         )->wait();

--- a/src/Listeners/PatchToBranch/Filter/ByConstraintOption.php
+++ b/src/Listeners/PatchToBranch/Filter/ByConstraintOption.php
@@ -18,7 +18,7 @@ final class ByConstraintOption
         $event->logger->info('Filtering patches by constraint argument.');
 
         $versionConstraints = $event->options->versionConstraints;
-        if (!empty($versionConstraints)) {
+        if (strlen($versionConstraints) > 0) {
             $event->filter(fn (DrupalOrgPatch $patch): bool => Semver::satisfies(
                 str_replace('.x', '.9999', $patch->getVersion()),
                 $versionConstraints,

--- a/src/Listeners/PatchToBranch/Filter/PrimaryTrunk.php
+++ b/src/Listeners/PatchToBranch/Filter/PrimaryTrunk.php
@@ -27,7 +27,7 @@ final class PrimaryTrunk
         $versionHwm = null;
         $event->filter(function (DrupalOrgPatch $patch) use (&$versionHwm, &$secondaries): bool {
             $patchVersion = $patch->getVersion();
-            if ($versionHwm && Comparator::lessThan($patchVersion, $versionHwm)) {
+            if (null !== $versionHwm && strlen($versionHwm) > 0 && Comparator::lessThan($patchVersion, $versionHwm)) {
                 // Skip this one.
                 $secondaries[] = $patch;
 

--- a/src/Listeners/PatchToBranch/FilterByResponse/ByBody.php
+++ b/src/Listeners/PatchToBranch/FilterByResponse/ByBody.php
@@ -26,7 +26,7 @@ final class ByBody
                 throw new \LogicException(sprintf('Missing patch contents for patch #%s %s', $patch->getParent()->getSequence(), $patch->getUrl()), 0, $e);
             }
 
-            if (empty($contents)) {
+            if (null === $contents || 0 === strlen($contents)) {
                 $logger->debug('Removed empty patch #{comment_id} {patch_url}.', [
                     'comment_id' => $patch->getParent()->getSequence(),
                     'patch_url' => $patch->getUrl(),

--- a/src/Listeners/PatchToBranch/GitBranch/GitBranch.php
+++ b/src/Listeners/PatchToBranch/GitBranch/GitBranch.php
@@ -17,7 +17,7 @@ final class GitBranch
     {
         $branchName = $event->options->branchName;
 
-        if (empty($branchName)) {
+        if (null === $branchName || 0 === strlen($branchName)) {
             $branchName = 'dogit-' . $event->issue->id() . '-' . $event->initialGitReference;
         }
 
@@ -44,7 +44,7 @@ final class GitBranch
         $event->gitIo->checkoutNew($branchName, 'origin/' . $event->initialGitReference);
         $event->logger->info('Checked out branch: ' . $branchName);
 
-        if ($deleteBranchName) {
+        if (null !== $deleteBranchName && strlen($deleteBranchName) > 0) {
             $event->logger->info('Deleting old branch {branch_name}', [
                 'branch_name' => $deleteBranchName,
             ]);
@@ -54,7 +54,7 @@ final class GitBranch
 
     private function branchToDeleteSuffix(string $branchName): string
     {
-        return $this->branchToDeleteSuffixGenerator
+        return null !== $this->branchToDeleteSuffixGenerator
             ? ($this->branchToDeleteSuffixGenerator)($branchName)
             : $branchName . '-to-delete-' . (string) time();
     }

--- a/src/Listeners/PatchToBranch/Terminate/Statistics.php
+++ b/src/Listeners/PatchToBranch/Terminate/Statistics.php
@@ -7,7 +7,6 @@ namespace dogit\Listeners\PatchToBranch\Terminate;
 use dogit\DrupalOrg\Objects\DrupalOrgComment;
 use dogit\DrupalOrg\Objects\DrupalOrgFile;
 use dogit\DrupalOrg\Objects\DrupalOrgIssue;
-use dogit\DrupalOrg\Objects\DrupalOrgObject;
 use dogit\DrupalOrg\Objects\DrupalOrgPatch;
 use dogit\Events\PatchToBranch\TerminateEvent;
 
@@ -21,7 +20,6 @@ final class Statistics
 
         $objectCounter = [];
         foreach ($event->repository->all() as $object) {
-            assert($object instanceof DrupalOrgObject);
             $objectCounter[$object::class] = ($objectCounter[$object::class] ?? 0) + 1;
         }
         $event->io->definitionList(

--- a/src/Listeners/PatchToBranch/Version/ByTestResultsEvent.php
+++ b/src/Listeners/PatchToBranch/Version/ByTestResultsEvent.php
@@ -26,7 +26,7 @@ final class ByTestResultsEvent
             // Get tests results for this comment.
             $testResults = array_filter(
                 $event->issueEvents,
-                fn (IssueEventInterface $event): bool => $event instanceof TestResultEvent && ($event->getComment()->id() == $patch->getParent()->id()) && !empty($event->version()),
+                fn (IssueEventInterface $event): bool => $event instanceof TestResultEvent && ($event->getComment()->id() == $patch->getParent()->id()) && strlen($event->version()) > 0,
             );
 
             $message = '[Untested]';
@@ -68,7 +68,7 @@ final class ByTestResultsEvent
                 'patch_url' => $patch->getUrl(),
                 'version' => $patch->getVersion(),
                 'git_reference' => $patch->getGitReference(),
-                'message' => !empty($message) ? ": $message" : '',
+                'message' => (strlen($message) > 0) ? ": $message" : '',
             ]);
         }
 

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -168,11 +168,11 @@ final class Utility
         }
 
         $firstComment = reset($allComments);
-        if ($firstVersionChange && $firstComment->id() !== $firstVersionChange->getComment()->id()) {
+        if (null !== $firstVersionChange && $firstComment->id() !== $firstVersionChange->getComment()->id()) {
             // Create a status for the first comment based on the *from* of the
             // first status.
             array_unshift($events, new VersionChangeEvent($firstComment, '', $firstVersionChange->from()));
-        } elseif (!$firstVersionChange) {
+        } elseif (null === $firstVersionChange) {
             // Otherwise if there are no status change events on the issue yet,
             // then create one for the first comment with the current issue status.
             array_unshift($events, new VersionChangeEvent($firstComment, '', $issue->getCurrentVersion()));
@@ -242,7 +242,6 @@ final class Utility
     public static function drupalProjectNameFromComposerJson(string $directory, Finder $finder): string
     {
         foreach ($finder->files()->in([$directory])->depth(0)->name(['composer.json']) as $file) {
-            assert($file instanceof \SplFileInfo);
             try {
                 $composer = \json_decode($file->getContents(), true, flags: \JSON_THROW_ON_ERROR);
             } catch (\JsonException $e) {
@@ -250,7 +249,7 @@ final class Utility
             }
 
             $composerName = $composer['name'] ?? null;
-            if (!$composerName) {
+            if (null === $composerName || 0 === strlen($composerName)) {
                 throw new \InvalidArgumentException('Missing Composer project name');
             }
 

--- a/tests/UtilityTest.php
+++ b/tests/UtilityTest.php
@@ -185,6 +185,7 @@ class UtilityTest extends TestCase
      */
     public function testVersionAt(): void
     {
+        $events = [];
         $events[] = new VersionChangeEvent(DrupalOrgComment::fromResponse(new Response(200, [], (string) \json_encode([
             'cid' => '10',
             'created' => (new \DateTimeImmutable('1 June 1996'))->getTimestamp(),
@@ -210,6 +211,7 @@ class UtilityTest extends TestCase
      */
     public function testVersionAtBeforeFirstComment(): void
     {
+        $events = [];
         $events[] = new VersionChangeEvent(DrupalOrgComment::fromResponse(new Response(200, [], (string) \json_encode([
             'cid' => '10',
             'created' => (new \DateTimeImmutable('1 June 1996'))->getTimestamp(),
@@ -227,6 +229,7 @@ class UtilityTest extends TestCase
      */
     public function testVersionAtBeforeVersionChangeEvent(): void
     {
+        $events = [];
         $comment1 = DrupalOrgComment::fromResponse(new Response(200, [], (string) \json_encode([
             'cid' => '1',
             'created' => (new \DateTimeImmutable('1 May 1996'))->getTimestamp(),
@@ -259,6 +262,7 @@ class UtilityTest extends TestCase
      */
     public function testVersionAtNoVersionChangeEvents(): void
     {
+        $events = [];
         $comment1 = DrupalOrgComment::fromResponse(new Response(200, [], (string) \json_encode([
             'cid' => '1',
             'created' => (new \DateTimeImmutable('1 May 1996'))->getTimestamp(),


### PR DESCRIPTION
https://github.com/phpstan/phpstan-strict-rules

Added permanent ignore for [PHPUnit _Static vs. Non-Static Usage of Assertion Methods_](https://phpunit.readthedocs.io/en/9.5/assertions.html), per docs both are allowed:

> A common question, especially from developers new to PHPUnit, is whether using $this->assertTrue() or self::assertTrue(), for instance, is “the right way” to invoke an assertion. The short answer is: there is no right way. And there is no wrong way, either. It is a matter of personal preference.