### PR TITLE
Move dev deps to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "phpstan/phpstan": "1.10.32",
         "phpstan/phpstan-strict-rules": "^1.4.2",
         "phpstan/phpstan-symfony": "^1.2.6",
-        "phpunit/phpunit": "^9.5.25"
+        "phpunit/phpunit": "^9.5.25",
         "phpspec/prophecy": "^1.15",
         "phpspec/prophecy-phpunit": "^2.0.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,6 @@
         "php-http/guzzle7-adapter": "^1.0",
         "php-http/httplug-bundle": "^1.27",
         "php-http/message": "^1.13",
-        "phpspec/prophecy": "^1.15",
-        "phpspec/prophecy-phpunit": "^2.0.1",
         "psr/http-client": "^1.0.1",
         "psr/log": "^3.0",
         "symfony/browser-kit": "^6.0.11",
@@ -41,6 +39,8 @@
         "phpstan/phpstan-strict-rules": "^1.4.2",
         "phpstan/phpstan-symfony": "^1.2.6",
         "phpunit/phpunit": "^9.5.25"
+        "phpspec/prophecy": "^1.15",
+        "phpspec/prophecy-phpunit": "^2.0.1"
     },
     "config": {
         "sort-packages": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3c6d772fc9ecf63ed2d52e45fe026112",
+    "content-hash": "30dd48adf2fa84442a126ec788deefb6",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -7248,5 +7248,5 @@
     "platform-overrides": {
         "php": "8.0.99999999"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
PHPUnit is being installed globally when composer requiring this library.

```
❯ composer why phpunit/phpunit
phpspec/prophecy-phpunit v2.0.2 requires phpunit/phpunit (^9.1) 

~/.composer 🐘 v8.3.8 
❯ composer why phpspec/prophecy-phpunit
dpi/dogit 1.1.4 requires phpspec/prophecy-phpunit (^2.0.1) 
```